### PR TITLE
udpating the versions of terraform for the  images

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is intended for people who want to build their docker images from t
 ## Some advise
 Now the latest version images will come by default with Terraform v0.13.0 or higher for the correct operation of the command `terraform login`.
 
-Some previous versions of the images remain available on Docker Hub with their respective latest tags.
+Some previous versions of the images remain available on Docker Hub with their respective tags.
 > Terraform v0.12.18
 * [terraform-docker:entrypoint](https://hub.docker.com/layers/stashconsulting/terraform-docker/entrypoint-d279264/images/sha256-6b677b94011b75c7442ce7b96650c1553fe15fef766f0ca09011a33dcca2fe39?context=repo), released on 18 August 2020.
 * [terraform-docker:standard](https://hub.docker.com/layers/stashconsulting/terraform-docker/standard-d279264/images/sha256-7a7cc0d703bdfdbc29444befe8e4083c5578f9ce2d5740e51705a87c9db3cbe1?context=repo), released on 18 August 2020.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ Integration between Terraform and Docker.
 
 This project is intended for people who want to build their docker images from terraform.
 
+## Some advise
+Now the latest version images will come by default with Terraform v0.13.0 or higher for the correct operation of the command `terraform login`.
+
+Some previous versions of the images remain available on Docker Hub with their respective latest tags.
+> Terraform v0.12.18
+* [terraform-docker:entrypoint](https://hub.docker.com/layers/stashconsulting/terraform-docker/entrypoint-d279264/images/sha256-6b677b94011b75c7442ce7b96650c1553fe15fef766f0ca09011a33dcca2fe39?context=repo), released on 18 August 2020.
+* [terraform-docker:standard](https://hub.docker.com/layers/stashconsulting/terraform-docker/standard-d279264/images/sha256-7a7cc0d703bdfdbc29444befe8e4083c5578f9ce2d5740e51705a87c9db3cbe1?context=repo), released on 18 August 2020.
+* [terraform-docker:gcloud](https://hub.docker.com/layers/stashconsulting/terraform-docker/gcloud-d279264/images/sha256-189ffac5d02f0780936371680bdf3bfe4b5de08b9c04c7eb4fe6790ae2592d75?context=repo), released on 18 August 2020.
+
+
 ## Getting Started
 
 ### Usage

--- a/entrypoint/Dockerfile
+++ b/entrypoint/Dockerfile
@@ -6,7 +6,7 @@ RUN  apt-get update \
   && apt-get install -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q  https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_linux_amd64.zip -O terraform.zip
+RUN wget -q  https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip -O terraform.zip
 
 RUN unzip terraform.zip
 

--- a/gcloud/Dockerfile
+++ b/gcloud/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH $PATH:/workspace/google-cloud-sdk/bin
 
 RUN gcloud --quiet components update
 
-RUN wget -q  https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_linux_amd64.zip -O terraform.zip \
+RUN wget -q  https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip -O terraform.zip \
    && unzip terraform.zip \
    && mv terraform /usr/local/bin
 

--- a/standard/Dockerfile
+++ b/standard/Dockerfile
@@ -6,7 +6,7 @@ RUN  apt-get update \
   && apt-get install -y wget unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q  https://releases.hashicorp.com/terraform/0.12.18/terraform_0.12.18_linux_amd64.zip -O terraform.zip && \
+RUN wget -q  https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip && \
   mv terraform /usr/local/bin/terraform && \
   rm terraform.zip 


### PR DESCRIPTION
# Pull Request Template

Thanks you for your contribution to the `terraform-docker` repo. 

## Description

* The latest version images will come by default with Terraform v0.13.0 or higher for the correct operation of the command `terraform login`.

Fixes # (issue)

## Type of change
> Choose below

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

**System Information**:
* Docker Info: 19.03.8

## Before creating the pull  request

-  My code follows the contributing guidelines of this project
- I have performed a self-review of my own code
- I have made corresponding changes to the documentation
